### PR TITLE
0.5.1 dev

### DIFF
--- a/ChangeLog-1.0.md
+++ b/ChangeLog-1.0.md
@@ -6,6 +6,19 @@ All notable changes of the Blast orm 1.0 release series are documented in this f
 
 ### Fixes
 
+ - Fix bug: Use configured collection from definition instead of always \SplStack
+
+### Altered
+
+ - Add definition tests for mapper and query
+ - Rename query `before` event to `build` 
+ - Rename query `after` event to `result` 
+ - Update readme
+
+## 0.5
+
+### Fixes
+
  - Fix bug where plain object don't get data from hydrator
  - Fix bug throwing exception when attaching relation without name
 

--- a/ChangeLog-1.0.md
+++ b/ChangeLog-1.0.md
@@ -2,7 +2,7 @@
 
 All notable changes of the Blast orm 1.0 release series are documented in this file using the [Keep a CHANGELOG](http://keepachangelog.com/) principles.
 
-## 0.5
+## 0.5.1
 
 ### Fixes
 

--- a/README.md
+++ b/README.md
@@ -341,6 +341,21 @@ class Post
 
 ```
 
+#### Definition
+
+In addition to auto-suggest definition from provider transformer, it is 
+also possible to use definition instead of entity.
+
+```php
+<?php
+
+class Post
+{
+
+}
+
+```
+
 #### Provider
 
 Providers are used to determine the entity definition and hydrate data to entity and vice versa. You could pass an 
@@ -370,7 +385,7 @@ $provider = new Provider('user_roles');
 
 Add definition to entity by public static property or method.
 
-#### Table name 
+##### Table name 
 
 Return table name as `string`
 
@@ -394,7 +409,7 @@ class Post
 
 ```
 
-#### Primary key name
+##### Primary key name
  
 Return primary key name as `string`
  
@@ -419,7 +434,7 @@ class Post
 
 ```
 
-#### Mapper
+##### Mapper
 
 Return mapper class name as `string` or a instance of `Blast\Orm\MapperInterface`
 
@@ -445,7 +460,7 @@ class Post
 
 ```
 
-#### Relations
+##### Relations
 
 Return relations as `array` containing instance of `Blast\Orm\Relations\RelationInterface`.
 
@@ -474,7 +489,7 @@ class Post
 
 ```
 
-#### Access definition from provider
+##### Access definition from provider
 
 Adapters grant access to data and definition, even if your entity class does not have definitions at all.
 

--- a/src/Hydrator/ArrayToObjectHydrator.php
+++ b/src/Hydrator/ArrayToObjectHydrator.php
@@ -21,7 +21,7 @@ class ArrayToObjectHydrator implements HydratorInterface
 {
 
     /**
-     * @var \Blast\Orm\Entity\ProviderInterface
+     * @var \Blast\Orm\Entity\Provider
      */
     private $provider;
 
@@ -94,7 +94,7 @@ class ArrayToObjectHydrator implements HydratorInterface
      */
     protected function hydrateCollection($data)
     {
-        $stack = new \SplStack();
+        $stack = $this->provider->getDefinition()->getEntityCollection();
         foreach ($data as $key => $value) {
             $stack->push($this->hydrateEntity($value));
         }

--- a/src/Query.php
+++ b/src/Query.php
@@ -162,7 +162,7 @@ class Query implements ConnectionAwareInterface, EmitterAwareInterface,
     private function beforeExecute($entity)
     {
         $builder = $this;
-        $event = $this->getEmitter()->emit(new QueryBuilderEvent('before.' . $this->getTypeName(), $builder));
+        $event = $this->getEmitter()->emit(new QueryBuilderEvent('build.' . $this->getTypeName(), $builder));
 
         if ($entity instanceof EmitterAwareInterface) {
             $event = $entity->getEmitter()->emit($event);
@@ -182,7 +182,7 @@ class Query implements ConnectionAwareInterface, EmitterAwareInterface,
     private function afterExecute($result, $entity, $builder)
     {
 
-        $event = $this->getEmitter()->emit(new QueryResultEvent('after.' . $builder->getTypeName(), $result), $builder);
+        $event = $this->getEmitter()->emit(new QueryResultEvent('result.' . $builder->getTypeName(), $result), $builder);
 
         if ($entity instanceof EmitterAwareInterface) {
             $event = $entity->getEmitter()->emit($event, $builder);

--- a/tests/Entity/TransformerTest.php
+++ b/tests/Entity/TransformerTest.php
@@ -14,6 +14,7 @@
 namespace Blast\Tests\Orm\Entity;
 
 
+use Blast\Orm\Entity\Definition;
 use Blast\Orm\Entity\Transformer;
 use Blast\Orm\MapperInterface;
 use Blast\Tests\Orm\Stubs\Entities\Post;

--- a/tests/MapperTest.php
+++ b/tests/MapperTest.php
@@ -8,8 +8,10 @@
 
 namespace Blast\Tests\Orm;
 
+use Blast\Orm\Entity\Definition;
 use Blast\Orm\Entity\Provider;
 use Blast\Orm\Mapper;
+use Blast\Orm\Relations\RelationInterface;
 use Blast\Tests\Orm\Stubs\Entities\Post;
 use Blast\Tests\Orm\Stubs\Entities\PostWithUserRelation;
 use Blast\Tests\Orm\Stubs\Entities\User;
@@ -142,13 +144,16 @@ class MapperTest extends AbstractDbTestCase
         $mapper = new Mapper(PostWithUserRelation::class);
         $result = $mapper->find(1)->execute();
 
-        $provider = new Provider($result);
-        $relations = [];
+        $this->assertInstanceOf(RelationInterface::class, $result['users']);
+    }
 
-        foreach($provider->getRelations() as $relation){
-            $relations[$relation->getName()] = $relation->execute();
-        }
+    public function testUseDefinition(){
+        $definition = new Definition([
+            'tableName' => 'user_role'
+        ]);
+        $mapper = new Mapper(new Provider($definition));
+        $result = $mapper->select()->setMaxResults(1)->execute();
 
-//        $this->assertEquals($result, 1);
+        $this->assertInstanceOf(RelationInterface::class, $result['users']);
     }
 }

--- a/tests/MapperTest.php
+++ b/tests/MapperTest.php
@@ -148,12 +148,14 @@ class MapperTest extends AbstractDbTestCase
     }
 
     public function testUseDefinition(){
-        $definition = new Definition([
+        $definition = new Definition();
+        $definition->setConfiguration([
             'tableName' => 'user_role'
         ]);
-        $mapper = new Mapper(new Provider($definition));
+        $mapper = new Mapper($definition);
         $result = $mapper->select()->setMaxResults(1)->execute();
 
-        $this->assertInstanceOf(RelationInterface::class, $result['users']);
+        $this->assertEquals(1, $result['user_pk']);
+        $this->assertEquals(1, $result['role_id']);
     }
 }

--- a/tests/QueryTest.php
+++ b/tests/QueryTest.php
@@ -11,15 +11,18 @@
  *
  */
 
-namespace Blast\Tests\Orm\Query;
+namespace Blast\Tests\Orm;
 
 
 use Blast\Orm\ConnectionManager;
+use Blast\Orm\Entity\Definition;
 use Blast\Orm\Hydrator\HydratorInterface;
+use Blast\Orm\Mapper;
 use Blast\Orm\Query;
 use Blast\Orm\Query\Events\QueryBuilderEvent;
 use Blast\Orm\Query\Events\QueryResultEvent;
 use Blast\Tests\Orm\AbstractDbTestCase;
+use Blast\Tests\Orm\Stubs\Entities\Post;
 use Doctrine\DBAL\Query\QueryBuilder;
 use stdClass;
 
@@ -81,15 +84,15 @@ class QueryTest extends AbstractDbTestCase
         $query = new Query();
 
         //force entity to be a stdClass
-        $query->getEmitter()->addListener('before.select', function (QueryBuilderEvent $event) {
-            $event->getBuilder()->setEntity(new \stdClass());
+        $query->getEmitter()->addListener('build.select', function (QueryBuilderEvent $event) {
+            $event->getBuilder()->setEntity(Post::class);
         });
 
         $result = $query->select()->from('post')->where('id = 1')->execute();
 
-        $query->getEmitter()->removeAllListeners('before.select');
+        $query->getEmitter()->removeAllListeners('build.select');
 
-        $this->assertInstanceOf(\stdClass::class, $result);
+        $this->assertInstanceOf(Post::class, $result);
     }
 
     /**
@@ -100,14 +103,14 @@ class QueryTest extends AbstractDbTestCase
         $query = new Query();
 
         //force entity to be a stdClass
-        $query->getEmitter()->addListener('before.select', function (QueryBuilderEvent $event) {
+        $query->getEmitter()->addListener('build.select', function (QueryBuilderEvent $event) {
             $event->setCanceled(true);
         });
 
         $result = $query->select()->from('post')->execute();
         $this->assertFalse($result);
 
-        $query->getEmitter()->removeAllListeners('before.select');
+        $query->getEmitter()->removeAllListeners('build.select');
 
     }
 
@@ -119,7 +122,7 @@ class QueryTest extends AbstractDbTestCase
         $query = new Query();
 
         //add additional value to result set
-        $query->getEmitter()->addListener('after.select', function (QueryResultEvent $event, Query $builder) {
+        $query->getEmitter()->addListener('result.select', function (QueryResultEvent $event, Query $builder) {
             $result = $event->getResult();
 
             foreach ($result as $key => $value) {
@@ -134,6 +137,8 @@ class QueryTest extends AbstractDbTestCase
         $data = $result->getArrayCopy();
 
         $this->assertEquals($data['contentSize'], strlen($data['content']));
+        
+        $query->getEmitter()->removeAllListeners('result.select');
     }
 
     /**
@@ -144,14 +149,14 @@ class QueryTest extends AbstractDbTestCase
         $query = new Query();
 
         //force entity to be a stdClass
-        $query->getEmitter()->addListener('after.select', function (QueryResultEvent $event) {
+        $query->getEmitter()->addListener('result.select', function (QueryResultEvent $event) {
             $event->setCanceled(true);
         });
 
         $result = $query->select()->from('post')->execute();
         $this->assertFalse($result);
 
-        $query->getEmitter()->removeAllListeners('after.select');
+        $query->getEmitter()->removeAllListeners('result.select');
 
     }
 
@@ -203,5 +208,18 @@ class QueryTest extends AbstractDbTestCase
         $query = new Query($connection);
         $query->setBuilder($connection->createQueryBuilder());
         $this->assertEquals($builder, $query->getBuilder());
+    }
+
+
+    public function testUseDefinition(){
+        $definition = new Definition();
+        $definition->setConfiguration([
+            'tableName' => 'user_role'
+        ]);
+        $query = new Query(ConnectionManager::getInstance()->get(), $definition);
+        $result = $query->select()->from($definition->getTableName())->setMaxResults(1)->execute();
+
+        $this->assertEquals(1, $result['user_pk']);
+        $this->assertEquals(1, $result['role_id']);
     }
 }


### PR DESCRIPTION
## 0.5.1
### Fixes
- Fix bug: Use configured collection from definition instead of always \SplStack
### Altered
- Add definition tests for mapper and query
- Rename query `before` event to `build` 
- Rename query `after` event to `result` 
- Update readme
