### PR TITLE
## 0.6.1

### DIFF
--- a/ChangeLog-1.0.md
+++ b/ChangeLog-1.0.md
@@ -2,6 +2,17 @@
 
 All notable changes of the Blast orm 1.0 release series are documented in this file using the [Keep a CHANGELOG](http://keepachangelog.com/) principles.
 
+## 0.6.1
+
+### Added
+
+ - `\Blast\Orm\QueryFactoryInterface` act as contract for query creation
+ - `\Blast\Orm\Connection` acts as connection wrapper for doctrine connection and is able to create connection-aware mappers and queries. createQueryBuilder is still creating doctrine SQL query builder!
+
+### Altered
+
+ - `\Blast\Orm\MapperFactoryInterface` is not forcing to add a connection
+
 ## 0.6.0
 
 ### Altered

--- a/README.md
+++ b/README.md
@@ -174,7 +174,32 @@ $connections->setDefaultConnection('another');
 
 The query object is is providing high level API methods of [doctrine 2 query builder](http://docs.doctrine-project.org/projects/doctrine-dbal/en/latest/reference/query-builder.html#security-safely-preventing-sql-injection).
 
-The query is automatically determining current active connection from connection manager.
+Create query from connection
+
+```php
+<?php
+
+$query = $connection->createQuery();
+```
+
+with entity
+
+```php
+<?php
+
+$query = $connection->createQuery(Post::class);
+```
+
+with definition
+
+```php
+<?php
+
+$query = $connection->createQuery($definition);
+
+```
+
+Create a new query instance, the query is automatically determining current active connection from connection manager.
 
 ```php
 <?php
@@ -662,6 +687,15 @@ The mapper prepares queries for data persistence and access of a provided entity
 instance and need to execute manually. It is also possible to add event listeners for query
 
 #### Create a new mapper for entity
+
+Get entity specific mapper from connection 
+
+```php
+<?php
+
+$mapper = $connection->getMapper($post);
+
+```
 
 Get entity specific mapper from provider
 

--- a/src/Connection.php
+++ b/src/Connection.php
@@ -1,0 +1,67 @@
+<?php
+/**
+ *
+ * (c) Marco Bunge <marco_bunge@web.de>
+ *
+ * For the full copyright and license information, please view the LICENSE.txt
+ * file that was distributed with this source code.
+ *
+ * Date: 13.04.2016
+ * Time: 08:20
+ *
+ */
+
+namespace Blast\Orm;
+
+
+use Doctrine\DBAL\Connection as DbalConnection;
+use Doctrine\DBAL\Query\QueryBuilder;
+
+/**
+ * The connection wrapper provides connection-aware mapper and query based on current connection
+ *
+ *
+ * @package Blast\Orm
+ */
+class Connection extends DbalConnection implements MapperFactoryInterface
+{
+
+    use MapperFactoryTrait {
+        createMapper as protected internalCreateMapper;
+    }
+
+    /**
+     * Create a new Mapper for given entity.
+     *
+     *  * ```php
+     *
+     * //create mapper from connection
+     * $connection->createMapper(Post::class);
+     *
+     * ```
+     *
+     * @param $entity
+     *
+     * @return Mapper
+     */
+    public function createMapper($entity){
+        return $this->internalCreateMapper($entity, $this);
+    }
+
+    /**
+     * Create a new query for given entity with optional custom query builder.
+     *
+     * @param $entity
+     *
+     * @param \Doctrine\DBAL\Query\QueryBuilder $builder
+     *
+     * @return Mapper
+     */
+    public function createQuery($entity, QueryBuilder $builder = null)
+    {
+        $query = new Query($this, $entity);
+        $query->setBuilder(null === $builder ? parent::createQueryBuilder() : $builder);
+        return $query;
+    }
+
+}

--- a/src/ConnectionManager.php
+++ b/src/ConnectionManager.php
@@ -9,6 +9,7 @@
 namespace Blast\Orm;
 
 use Doctrine\DBAL\Connection;
+use Blast\Orm\Connection as ConnectionWrapper;
 use Doctrine\DBAL\DBALException;
 use Doctrine\DBAL\DriverManager;
 
@@ -61,7 +62,7 @@ class ConnectionManager implements ConnectionManagerInterface
      * class from container.
      *
      * @param $definition
-     * @return Connection
+     * @return \Doctrine\DBAL\Connection|\Blast\Orm\Connection
      *
      * @throws \Doctrine\DBAL\DBALException
      */
@@ -80,6 +81,10 @@ class ConnectionManager implements ConnectionManagerInterface
 
         if (!is_array($definition)) {
             throw new DBALException('Unable to determine parameter array from definition');
+        }
+
+        if(!array_key_exists('wrapperClass', $definition)){
+            $definition['wrapperClass'] = ConnectionWrapper::class;
         }
 
         $connection = DriverManager::getConnection($definition);
@@ -147,9 +152,7 @@ class ConnectionManager implements ConnectionManagerInterface
             throw new DBALException(sprintf('Connection with name %s already exists!', $name));
         }
 
-        $connection = static::create($connection);
-
-        $this->connections[$name] = $connection;
+        $this->connections[$name] = static::create($connection);
 
         //set first connection as active connection
         if (count($this->connections) === 1) {
@@ -200,7 +203,7 @@ class ConnectionManager implements ConnectionManagerInterface
      *
      * @param $name
      *
-     * @return \Doctrine\DBAL\Connection
+     * @return \Doctrine\DBAL\Connection|\Blast\Orm\Connection
      *
      * @throws \Doctrine\DBAL\DBALException
      */

--- a/src/QueryFactoryInterface.php
+++ b/src/QueryFactoryInterface.php
@@ -6,22 +6,22 @@
  * For the full copyright and license information, please view the LICENSE.txt
  * file that was distributed with this source code.
  *
- * Date: 16.03.2016
- * Time: 17:25
+ * Date: 13.04.2016
+ * Time: 08:34
  *
  */
 
 namespace Blast\Orm;
 
 
-interface MapperFactoryInterface
+interface QueryFactoryInterface
 {
     /**
-     * Create a new Mapper for given entity.
+     * Create a new query for given entity.
      *
      * @param $entity
+     * 
      * @return Mapper
      */
-    public function createMapper($entity);
-
+    public function createQuery($entity);
 }

--- a/tests/ConnectionCollectionTest.php
+++ b/tests/ConnectionCollectionTest.php
@@ -11,6 +11,9 @@ namespace Blast\Tests\Orm;
 
 use Blast\Orm\ConnectionManager;
 use Blast\Orm\ConnectionManagerInterface;
+use Blast\Orm\Mapper;
+use Blast\Orm\Query;
+use Blast\Tests\Orm\Stubs\Entities\Post;
 use Doctrine\DBAL\Configuration;
 use Doctrine\DBAL\DBALException;
 use Doctrine\DBAL\Driver\Connection;
@@ -67,6 +70,16 @@ class ConnectionCollectionTest extends \PHPUnit_Framework_TestCase
 
         $this->assertInternalType('array', ConnectionManager::getInstance()->getPrevious());
         $this->assertInstanceOf(Connection::class, ConnectionManager::getInstance()->get());
+    }
+
+    /**
+     * Test orm own connection and access to query and mapper
+     */
+    public function testOrmConnection(){
+        $connection = ConnectionManager::create($this->dsn);
+
+        $this->assertInstanceOf(Mapper::class, $connection->createMapper(Post::class));
+        $this->assertInstanceOf(Query::class, $connection->createQuery(Post::class));
     }
 
     public function testExceptionWhenSetUnknownDefaultConnection()


### PR DESCRIPTION
### Added
- `\Blast\Orm\QueryFactoryInterface` act as contract for query creation
- `\Blast\Orm\Connection` acts as connection wrapper for doctrine connection and is able to create connection-aware mappers and queries. createQueryBuilder is still creating doctrine SQL query builder!
### Altered
- `\Blast\Orm\MapperFactoryInterface` is not forcing to add a connection
